### PR TITLE
fix: add rotate and step additonal checks + use custom errors for gas…

### DIFF
--- a/src/Spectre.sol
+++ b/src/Spectre.sol
@@ -145,9 +145,9 @@ contract Spectre {
             bytes32(proof[384 + 32:384 + 2 * 32])
         );
 
-        if (_publicInputsCommitment == publicInputsCommitment) revert InvalidPublicInputsCommitment();
+        if (_publicInputsCommitment != publicInputsCommitment) revert InvalidPublicInputsCommitment();
 
-        if (_syncCommitteePoseidon == syncCommitteePoseidon) revert InvalidSyncComitee();
+        if (_syncCommitteePoseidon != syncCommitteePoseidon) revert InvalidSyncComitee();
 
         (bool success, ) = stepVerifierAddress.call(proof);
         if (!success) {

--- a/src/Spectre.sol
+++ b/src/Spectre.sol
@@ -103,7 +103,7 @@ contract Spectre {
         );
         uint256 nextPeriod = currentPeriod + 1;
         if (syncCommitteePoseidons[nextPeriod] != 0) revert SyncCommitteeAlreadySet();
-        if (syncCommitteePoseidons[attestingPeriod] != 0) revert SyncCommiteeNotYetSetForPeriod();
+        if (syncCommitteePoseidons[attestingPeriod] == 0) revert SyncCommiteeNotYetSetForPeriod();
 
         _verifyStepProof(
             stepInput,

--- a/src/Spectre.sol
+++ b/src/Spectre.sol
@@ -38,6 +38,8 @@ contract Spectre {
     error InvalidFinalizedHeaderRoot();
     error InvalidPublicInputsCommitment();
     error InvalidSyncComitee();
+    error StepProofVerificationFailed();
+    error RotateProofVerificationFailed();
 
     constructor(
         address _stepVerifierAddress,
@@ -151,7 +153,7 @@ contract Spectre {
 
         (bool success, ) = stepVerifierAddress.call(proof);
         if (!success) {
-            revert("Step proof verification failed");
+            revert StepProofVerificationFailed();
         }
     }
 
@@ -174,7 +176,7 @@ contract Spectre {
 
         (bool success, ) = rotateVerifierAddress.call(proof);
         if (!success) {
-            revert("Rotate proof verification failed");
+            revert RotateProofVerificationFailed();
         }
     }
 }

--- a/test/Spectre.t.sol
+++ b/test/Spectre.t.sol
@@ -1,0 +1,38 @@
+// The Licensed Work is (c) 2023 ChainSafe
+// Code: https://github.com/ChainSafe/Spectre
+// SPDX-License-Identifier: LGPL-3.0-only
+
+pragma solidity 0.8.19;
+
+import "forge-std/Test.sol";
+import "../src/Spectre.sol";
+
+contract SpectreTest is Test {
+
+    Spectre internal spectre;
+
+    address constant stepVerifierAddress = address(0x95222290DD7278Aa3Ddd389Cc1E1d165CC4BAfe5);
+    address constant committeeUpdateVerifierAddress = address(0xE68badDE25D8389ae4b96962AC526D113f3BaC9D);
+    uint256 constant initialSyncPerios = 8;
+    uint256 constant initialSyncCommiteePoseidon = 10;
+    uint256 constant slotsPerPeriod = 64;
+    uint16 constant finalityThreshold = 20; // ~ 2/3 of 32
+
+    function setUp() public {
+        spectre = new Spectre(
+            stepVerifierAddress,
+            committeeUpdateVerifierAddress,
+            initialSyncPerios,
+            initialSyncCommiteePoseidon,
+            slotsPerPeriod,
+            finalityThreshold
+        );
+    }
+
+    function test_SpectreContractSuccessfullyInitialized() public {
+        assertEq(spectre.stepVerifierAddress(), stepVerifierAddress);
+        assertEq(spectre.rotateVerifierAddress(), committeeUpdateVerifierAddress);
+        assertEq(spectre.syncCommitteePoseidons(initialSyncPerios), initialSyncCommiteePoseidon);
+        assertEq(spectre.FINALITY_THRESHOLD(), finalityThreshold);
+    }
+}


### PR DESCRIPTION
This PR adds:
- check for rotate and step (if value already exists in mappings it will revert with Error)
- removes unused `head` const
- replaces `require` statements with custom errors to save on gas